### PR TITLE
Throw error to ensure correct exit code

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -52,7 +52,7 @@ var opt = {
 };
 
 sauceConnect(opt, function(error, tunnel) {
-  if (error) return console.error('error: %s'.red, error);
+  if (error) throw new Error('error: %s'.red, error);
 
   function close(code) {
     if (code) console.warn('child process exited (%d)'.red, code);


### PR DESCRIPTION
I’ve noticed that my CI job always reports with success since a few weeks but it logs an error message to the console output:

```
[...]
[sc] Sauce Connect API failure
error: Error: 14 Dec 12:07:46 - Sauce Connect could not establish a connection.
4 Dec 12:07:46 - Please check your firewall and proxy settings.
You can also use sc --doctor to launch Sauce Connect in diagnostic mode.
[...]
```

This is because the exit code of `sc-run` is still `0` even if an error occurs. Throwing the error instead of logging it solves this issue.
